### PR TITLE
Container is unhealthy due to removed healthcheck endpoint - update to '/api/healthz'

### DIFF
--- a/arch.dockerfile
+++ b/arch.dockerfile
@@ -105,7 +105,7 @@
 
 # :: HEALTH
   HEALTHCHECK --interval=5s --timeout=2s --start-period=5s \
-    CMD ["/usr/local/bin/localhealth", "http://127.0.0.1:3000/api/health", "-I"]
+    CMD ["/usr/local/bin/localhealth", "http://127.0.0.1:3000/api/healthz", "-I"]
 
 # :: EXECUTE
   USER ${APP_UID}:${APP_GID}


### PR DESCRIPTION
Currently, on tag 4.1.0, the container shows as unhealthy
```bash
# docker exec -it tinyauth /usr/local/bin/localhealth "http://127.0.0.1:3000/api/health" -I
http.NewRequest status code != 200: %!s(int=404)
```
This is an update to the new endpoint (/api/healthz) as shown in:
https://github.com/steveiliop56/tinyauth/blob/main/internal/controller/health_controller.go
https://tinyauth.app/docs/breaking-updates/3-to-4/#api-changes

